### PR TITLE
Automatic dependency updates

### DIFF
--- a/.github/workflows/auto_update.yaml
+++ b/.github/workflows/auto_update.yaml
@@ -12,5 +12,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    with:
+      flutterCompat: false
     secrets:
       githubToken: ${{ secrets.GH_PAT }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 2026-02-21
+### Changed
+- Updated min sdk version to ^3.11.0
+- Updated dependencies
+
 ## [1.4.1] - 2025-12-05
 ### Changed
 - Updated dependencies
@@ -102,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
+[1.4.2]: https://github.com/Skycoder42/podman_backup/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/Skycoder42/podman_backup/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/Skycoder42/podman_backup/compare/v1.3.5...v1.4.0
 [1.3.5]: https://github.com/Skycoder42/podman_backup/compare/v1.3.4...v1.3.5

--- a/lib/src/models/container.dart
+++ b/lib/src/models/container.dart
@@ -1,5 +1,4 @@
 // coverage:ignore-file
-// ignore_for_file: invalid_annotation_target
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/lib/src/models/volume.dart
+++ b/lib/src/models/volume.dart
@@ -1,5 +1,4 @@
 // coverage:ignore-file
-// ignore_for_file: invalid_annotation_target
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   injectable: ^2.7.1+4
   json_annotation: ^4.11.0
   logging: ^1.3.0
-  meta: ^1.17.0
+  meta: ^1.18.1
   posix: ^6.0.3
   rxdart: ^0.28.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: podman_backup
 description: A small dart tool to push regular backups of podman volumes to a remote.
 homepage: https://github.com/Skycoder42/podman_backup
-version: 1.4.1
+version: 1.4.2
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 platforms:
   linux:
@@ -18,24 +18,24 @@ dependencies:
   build_cli_annotations: ^2.1.1
   collection: ^1.19.1
   freezed_annotation: ^3.1.0
-  get_it: ^9.2.0
-  injectable: ^2.7.1
-  json_annotation: ^4.9.0
+  get_it: ^9.2.1
+  injectable: ^2.7.1+4
+  json_annotation: ^4.11.0
   logging: ^1.3.0
   meta: ^1.17.0
   posix: ^6.0.3
   rxdart: ^0.28.0
 
 dev_dependencies:
-  build_cli: ^2.2.8
-  build_runner: ^2.10.4
-  dart_pre_commit: ^6.1.0
-  dart_test_tools: ^7.0.1
-  freezed: ^3.2.3
-  injectable_generator: ^2.9.1
-  json_serializable: ^6.11.2
+  build_cli: ^2.2.10
+  build_runner: ^2.11.1
+  dart_pre_commit: ^6.1.1+1
+  dart_test_tools: ^7.0.2
+  freezed: ^3.2.5
+  injectable_generator: ^2.12.0
+  json_serializable: ^6.13.0
   mocktail: ^1.0.4
-  test: ^1.28.0
+  test: ^1.29.0
 
 aur:
   maintainer: Skycoder42 <Skycoder42@users.noreply.github.com>


### PR DESCRIPTION
### SDK Updates
- Settings sdk version for podman_backup to ^3.11.0
### Dependency Updates
```

Changed 11 constraints in pubspec.yaml:
  get_it: ^9.2.0 -> ^9.2.1
  injectable: ^2.7.1 -> ^2.7.1+4
  json_annotation: ^4.9.0 -> ^4.11.0
  build_cli: ^2.2.8 -> ^2.2.10
  build_runner: ^2.10.4 -> ^2.11.1
  dart_pre_commit: ^6.1.0 -> ^6.1.1+1
  dart_test_tools: ^7.0.1 -> ^7.0.2
  freezed: ^3.2.3 -> ^3.2.5
  injectable_generator: ^2.9.1 -> ^2.12.0
  json_serializable: ^6.11.2 -> ^6.13.0
  test: ^1.28.0 -> ^1.29.0
Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 92.0.0 (96.0.0 available)
  analysis_server_plugin 0.3.4 (0.3.10 available)
  analyzer 9.0.0 (10.2.0 available)
  analyzer_plugin 0.13.11 (0.14.4 available)
  dart_style 3.1.3 (3.1.5 available)
  lean_builder 0.1.6 (0.1.7 available)
  meta 1.17.0 (1.18.1 available)
  watcher 1.1.4 (1.2.1 available)
No dependencies changed.
8 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
```
